### PR TITLE
Add Aperisolve to Stegnography

### DIFF
--- a/Categories/Steganography/README.md
+++ b/Categories/Steganography/README.md
@@ -1,6 +1,7 @@
 # Stegnography
 - Steghide [Website](http://steghide.sourceforge.net/)
 - Pelock [Online Tool](https://www.pelock.com/products/steganography-online-codec)
+- Aperisolve [Online Tool](https://aperisolve.fr/)
 - Strings(CLI tool)
 - Exiftool [GitHub](https://github.com/exiftool/exiftool)
 - binwalk (CLI tool) [GitHub](https://gist.github.com/briankip/8f8747a2488af827e3b4)


### PR DESCRIPTION
Aperisolve contains more steganography methods (which includes steghide, zsteg, exiftool etc), increasing the likelihood of finding the plaintext.

Hope you find this useful, but if you think this is not needed it is fine to close this.

Thanks!